### PR TITLE
Added custom handler option.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,9 @@
       }
     ],
     "prefer-arrow-callback": "error",
-    "camelcase": "warn"
+    "camelcase": "warn",
+    "keyword-spacing": ["error", {
+      "after": true
+    }]
   }
 }

--- a/index.js
+++ b/index.js
@@ -28,14 +28,9 @@ module.exports = function conversation({name, app, appId,
   locale = 'en-US',
   fixSpaces = false,
   fuzzyDistance = 0.93,
-  handler = null
+  handler = (app && app.handler) || null
 }) {
-  let appHandler = function() { throw new Error("Must provide either an app or a handler."); };
-  if (handler) {
-    appHandler = handler;
-  } else if (app && app.handler) {
-    appHandler = app.handler;
-  }
+  if(handler === null) throw new Error("Must provide either an app or handler.");
 
   const requestBuilder = RequestBuilder.init({appId, sessionId, userId, accessToken, requestId, locale});
   // chain of promises to handle the different conversation steps
@@ -88,7 +83,7 @@ module.exports = function conversation({name, app, appId,
     const slots = slotsArg || {};
     const index = step;
     dialog = dialog.then(prevEvent =>
-      sendRequest(requestBuilder.build(intentName, slots, prevEvent), appHandler).then(res => {
+      sendRequest(requestBuilder.build(intentName, slots, prevEvent), handler).then(res => {
         tests[index] = _.extend(tests[index], {intentName, slots, actual: res});
         return res;
       })

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const _ = require('underscore');
 const RequestBuilder = require('./request-builder');
 const response = require('./response');
 
-function sendRequest(event, app) {
+function sendRequest(event, handler) {
   return new Promise((resolve, reject) => {
-    app.handler(event, {
+    handler(event, {
       succeed: resolve,
       fail: reject
     });
@@ -27,8 +27,16 @@ module.exports = function conversation({name, app, appId,
   requestId = 'EdwRequestId.33ac9138-640f-4e6e-ab71-b9619b2c2210',
   locale = 'en-US',
   fixSpaces = false,
-  fuzzyDistance = 0.93
+  fuzzyDistance = 0.93,
+  handler = null
 }) {
+  let appHandler = function() { throw new Error("Must provide either an app or a handler."); };
+  if (handler) {
+    appHandler = handler;
+  } else if (app && app.handler) {
+    appHandler = app.handler;
+  }
+
   const requestBuilder = RequestBuilder.init({appId, sessionId, userId, accessToken, requestId, locale});
   // chain of promises to handle the different conversation steps
   const conversationName = name;
@@ -80,7 +88,7 @@ module.exports = function conversation({name, app, appId,
     const slots = slotsArg || {};
     const index = step;
     dialog = dialog.then(prevEvent =>
-      sendRequest(requestBuilder.build(intentName, slots, prevEvent), app).then(res => {
+      sendRequest(requestBuilder.build(intentName, slots, prevEvent), appHandler).then(res => {
         tests[index] = _.extend(tests[index], {intentName, slots, actual: res});
         return res;
       })

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function conversation({name, app, appId,
   fuzzyDistance = 0.93,
   handler = (app && app.handler) || null
 }) {
-  if(handler === null) throw new Error("Must provide either an app or handler.");
+  if(handler === null) throw new Error('Must provide either an app or handler.');
 
   const requestBuilder = RequestBuilder.init({appId, sessionId, userId, accessToken, requestId, locale});
   // chain of promises to handle the different conversation steps

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function conversation({name, app, appId,
   fuzzyDistance = 0.93,
   handler = (app && app.handler) || null
 }) {
-  if(handler === null) throw new Error('Must provide either an app or handler.');
+  if (handler === null) throw new Error('Must provide either an app or handler.');
 
   const requestBuilder = RequestBuilder.init({appId, sessionId, userId, accessToken, requestId, locale});
   // chain of promises to handle the different conversation steps

--- a/readme.md
+++ b/readme.md
@@ -19,12 +19,15 @@ In your functional test files, include the `alexa-conversation` package
 ```js
 
 const conversation = require('alexa-conversation');
-const app = require('../../index.js'); // your Alexa skill's main file. `app.handle` needs to exist
+const app = require('../../index.js'); // your Alexa skill's main file.
 
 const opts = { // those will be used to generate the requests to your skill
   name: 'Test Conversation',
+  appId: 'your-app-id',
+  // Either provide your app (app.handler must exist)...
   app: app,
-  appId: 'your-app-id'
+  // ...or pass the handler in directly (for example, if you have a custom handler name)
+  handler: app.customHandlerName
   // Other optional parameters. See readme.md
 };
 
@@ -65,7 +68,8 @@ Initializes a new `conversation` and returns itself.
 #### Non-optional parameters:
 
 - `name` *String*: The name you want this conversation to have (useful for the test reports)
-- `app` *Object*: Your Alexa skill main app object (normally what is returned from your `index.js` file). It needs to expose `app.handle`.
+- `app` *Object*: Your Alexa skill main app object (normally what is returned from your `index.js` file). It either needs to expose `app.handler`, or you can pass in a `handler` instead (see below)
+- `handler` *Function*: If your app doesn't expose a `handler` method or you want to use a custom handler, you can pass the handler in directly - this will take precedence over `app.handler`
 - `appId` *String*: Your Alexa Skill Id in order to build requests that will be accepted by your skill.
 
 #### Optional parameters:


### PR DESCRIPTION
I added the ability to pass in the actual handler instead of just the app module, which fixes #8. This allows for custom handler names (not just `handler`).

Since the only time the passed in `app` module was being used was to grab the handler off of it, we could just replace the `app` option with `handler` instead of adding a new option. It would be a backwards-incompatible change though, which is why I've just added the new option in this pull request.